### PR TITLE
F5 account compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/terraform.tfvars
+azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/.terraform*
+azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/terraform.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/terraform.tfvars
-azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/.terraform*
-azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/terraform.tfstate*
+azure-quickstarts/**/terraform.tfvars
+azure-quickstarts/**/.terraform*
+azure-quickstarts/**/terraform.tfstate*

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/README.md
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/README.md
@@ -1,4 +1,5 @@
-# F5 Employees only
+# Updating trusted Source IP address
+
 ## Azure login
 
 1. `az login`

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/README.md
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/README.md
@@ -1,3 +1,4 @@
+# F5 Employees only
 ## Azure login
 
 1. `az login`
@@ -9,3 +10,7 @@ az account list -o table
 SUBSCRIPTION=<id>
 az account set --subscription $SUBSCRIPTION
 ```
+
+## Updating your source IP:
+
+Execute `./updateIP.py` prior running `terrafrom plan/apply`

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/README.md
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/README.md
@@ -1,0 +1,11 @@
+## Azure login
+
+1. `az login`
+2. set the correct subscription 
+```
+# view and select your subscription account
+
+az account list -o table
+SUBSCRIPTION=<id>
+az account set --subscription $SUBSCRIPTION
+```

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/application.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/application.tf
@@ -72,7 +72,8 @@ resource "azurerm_virtual_machine_scale_set" "appvmss" {
     }
   }
 
-  tags = {
+  tags = merge({
     discovery = var.service_discovery_value
-  }
+  },
+  local.tags)
 }

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/bigip1.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/bigip1.tf
@@ -7,6 +7,7 @@ resource "azurerm_public_ip" "bigip1_mgmt_pip" {
   location            = azurerm_resource_group.rg.location
   sku                 = "Standard"
   allocation_method   = "Static"
+  tags                = local.tags
 }
 
 resource "azurerm_public_ip" "bigip1_ext_pip" {
@@ -15,6 +16,7 @@ resource "azurerm_public_ip" "bigip1_ext_pip" {
   location            = azurerm_resource_group.rg.location
   sku                 = "Standard"
   allocation_method   = "Static"
+  tags                = local.tags
 }
 
 resource "azurerm_public_ip" "bigip1_ext_vpip" {
@@ -23,6 +25,7 @@ resource "azurerm_public_ip" "bigip1_ext_vpip" {
   location            = azurerm_resource_group.rg.location
   sku                 = "Standard"
   allocation_method   = "Static"
+  tags                = local.tags
 }
 
 # Network Interfaces BIGIP1
@@ -38,6 +41,8 @@ resource "azurerm_network_interface" "bigip1_management" {
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = azurerm_public_ip.bigip1_mgmt_pip.id
   }
+
+  tags                = local.tags
 }
 
 resource "azurerm_network_interface" "bigip1_external" {
@@ -61,10 +66,11 @@ resource "azurerm_network_interface" "bigip1_external" {
     public_ip_address_id          = azurerm_public_ip.bigip1_ext_vpip.id
   }
 
-  tags = {
+  tags = merge({
     f5_cloud_failover_label   = "${var.prefix}-failover-label"
     f5_cloud_failover_nic_map = "external"
-  }
+  },
+  local.tags)
 }
 
 resource "azurerm_network_interface" "bigip1_internal" {
@@ -80,10 +86,11 @@ resource "azurerm_network_interface" "bigip1_internal" {
     primary                       = true
   }
 
-  tags = {
+  tags = merge({
     f5_cloud_failover_label   = "${var.prefix}-failover-label"
     f5_cloud_failover_nic_map = "internal"
-  }
+  },
+  local.tags)
 }
 
 # Associate NSG with Network Interfaces
@@ -122,8 +129,8 @@ locals {
     remote_host_int         = azurerm_network_interface.bigip0_internal.private_ip_address 
     self_ip_external        = azurerm_network_interface.bigip1_external.private_ip_address
     self_ip_internal        = azurerm_network_interface.bigip1_internal.private_ip_address
-    management_gateway      = cidrhost(azurerm_subnet.management.address_prefix, 1)
-    external_gateway        = cidrhost(azurerm_subnet.external.address_prefix, 1)
+    management_gateway      = cidrhost(azurerm_subnet.management.address_prefixes[0], 1)
+    external_gateway        = cidrhost(azurerm_subnet.external.address_prefixes[0], 1)
     f5_cloud_failover_label = "${var.prefix}-failover-label"
     vip                     = element(azurerm_network_interface.bigip0_external.private_ip_addresses, 1)
     unique_string           = var.unique_string
@@ -165,5 +172,7 @@ resource "azurerm_linux_virtual_machine" "bigip1" {
     caching              = "None"
     storage_account_type = "Premium_LRS"
   }
+
+  tags                          = local.tags
 }
 

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/network.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/network.tf
@@ -4,6 +4,7 @@ resource "azurerm_virtual_network" "vnet" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   address_space       = [var.cidr]
+  tags                = local.tags
 }
 
 #Create the Subnets
@@ -43,8 +44,9 @@ resource "azurerm_route_table" "cfe_udr" {
     next_hop_in_ip_address = azurerm_network_interface.bigip0_internal.private_ip_address
   }
 
-  tags = {
+  tags = merge({
     f5_cloud_failover_label = "${var.prefix}-failover-label"
     f5_self_ips             = "${azurerm_network_interface.bigip0_internal.private_ip_address}, ${azurerm_network_interface.bigip1_internal.private_ip_address}"
-  }
+  },
+  local.tags)
 }

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/security.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/security.tf
@@ -15,7 +15,7 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = var.employee_IP
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -28,7 +28,7 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
-    source_address_prefix      = var.employee_IP
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -53,7 +53,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = var.employee_IP
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -66,7 +66,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
-    source_address_prefix      = var.employee_IP
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -79,7 +79,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "8443"
-    source_address_prefix      = var.employee_IP
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -92,7 +92,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "80"
-    source_address_prefix      = var.employee_IP
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/security.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/security.tf
@@ -32,10 +32,11 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     destination_address_prefix = "*"
   }
 
-  tags = {
+  tags = merge({
     name        = "${var.prefix}-mgmtnsg"
     environment = var.environment
-  }
+  },
+  local.tags)
 }
 
 resource "azurerm_network_security_group" "extnsg" {
@@ -95,10 +96,11 @@ resource "azurerm_network_security_group" "extnsg" {
     destination_address_prefix = "*"
   }
 
-  tags = {
+  tags = merge({
     name        = "${var.prefix}-extnsg"
     environment = var.environment
-  }
+  },
+  local.tags)
 }
 
 resource "azurerm_network_security_group" "intnsg" {
@@ -132,8 +134,9 @@ resource "azurerm_network_security_group" "intnsg" {
     destination_address_prefix = "*"
   }
 
-  tags = {
+  tags = merge({
     name        = "${var.prefix}-intnsg"
     environment = var.environment
-  }
+  },
+  local.tags)
 }

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/security.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/security.tf
@@ -15,7 +15,7 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.employee_IP
     destination_address_prefix = "*"
   }
 
@@ -28,7 +28,7 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.employee_IP
     destination_address_prefix = "*"
   }
 
@@ -53,7 +53,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.employee_IP
     destination_address_prefix = "*"
   }
 
@@ -66,7 +66,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.employee_IP
     destination_address_prefix = "*"
   }
 
@@ -79,7 +79,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "8443"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.employee_IP
     destination_address_prefix = "*"
   }
 
@@ -92,7 +92,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "80"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.employee_IP
     destination_address_prefix = "*"
   }
 

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/telemetry.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/telemetry.tf
@@ -9,6 +9,7 @@ resource "azurerm_log_analytics_workspace" "law" {
   retention_in_days   = 90
   depends_on = [ azurerm_resource_group.rg
   ]
+  tags                = local.tags
 }
 
 #Create Azure Log Analytics Workbook
@@ -34,4 +35,5 @@ resource "azurerm_application_insights" "web" {
   location            = azurerm_resource_group.rg.location
   workspace_id        = azurerm_log_analytics_workspace.law.id
   application_type    = "other"
+  tags                = local.tags
 }

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/telemetry.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/telemetry.tf
@@ -7,8 +7,7 @@ resource "azurerm_log_analytics_workspace" "law" {
   location            = azurerm_resource_group.rg.location
   sku                 = "PerGB2018"
   retention_in_days   = 90
-  depends_on = [ azurerm_resource_group.rg
-  ]
+  depends_on = [ azurerm_resource_group.rg ]
   tags                = local.tags
 }
 

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/updateIP.py
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/updateIP.py
@@ -14,9 +14,9 @@ response = requests.get(url)
 with fileinput.input(files="terraform.tfvars",inplace=True) as input:
     for line in input:
         input_line = ''
-        search_string = re.findall(r'employee_IP',line.strip())
+        search_string = re.findall(r'trusted_IP',line.strip())
         if len(search_string) >0 :
-            input_line = "employee_IP       = \"" + str(response.text)+"/32\""
+            input_line = "trusted_IP       = \"" + str(response.text)+"/32\""
             print(input_line)
         else:
             print(line.strip())

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/updateIP.py
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/updateIP.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import requests
+import os
+import re
+import fileinput
+
+url = 'http://ifconfig.me/ip'
+
+response = requests.get(url)
+
+# print (response.content)
+
+with fileinput.input(files="terraform.tfvars",inplace=True) as input:
+    for line in input:
+        input_line = ''
+        search_string = re.findall(r'employee_IP',line.strip())
+        if len(search_string) >0 :
+            input_line = "employee_IP       = \"" + str(response.text)+"/32\""
+            print(input_line)
+        else:
+            print(line.strip())
+
+# os.system("terraform apply -target module.remote_access.module.external-network-security-group-public.aws_security_group_rule.ingress_rules[0] -auto-approve")
+# for x in range (1,4):
+#    os_command="terraform apply -target module.remote_access.module.mgmt-network-security-group.aws_security_group_rule.ingress_with_cidr_blocks["+str(x)+"] -auto-approve"
+#    os.system(os_command)

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/variables.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/variables.tf
@@ -11,6 +11,12 @@ variable "prefix" {}
 variable "unique_string" {}
 variable "location" {}
 
+# F5 employee required:
+variable "owner" {
+  type                  = string
+  description           = "Employee e-mail address"
+}
+
 #Tags
 variable "environment" { default = "azure" }
 variable "service_discovery_value" { default = "production" }

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/variables.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/variables.tf
@@ -11,7 +11,6 @@ variable "prefix" {}
 variable "unique_string" {}
 variable "location" {}
 
-# F5 employee required:
 variable "owner" {
   type                  = string
   description           = "Employee e-mail address"
@@ -41,8 +40,7 @@ variable "subnet_internal" {
 variable "management_gateway" { default = "10.0.0.1"}
 variable "external_gateway" { default = "10.0.1.1"}
 
-# F5 employee required:
-variable "employee_IP" {
+variable "trusted_IP" {
   type    = string 
 }
 

--- a/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/variables.tf
+++ b/azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api/variables.tf
@@ -41,6 +41,11 @@ variable "subnet_internal" {
 variable "management_gateway" { default = "10.0.0.1"}
 variable "external_gateway" { default = "10.0.1.1"}
 
+# F5 employee required:
+variable "employee_IP" {
+  type    = string 
+}
+
 # BIGIP Image PAYG
 variable "instance_type" { default = "Standard_DS3_v2" }
 variable "image_name" { default = "f5-bigip-virtual-edition-25m-best-hourly" }

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/README.md
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/README.md
@@ -1,0 +1,17 @@
+# Updating trusted Source IP address
+
+## Azure login
+
+1. `az login`
+2. set the correct subscription 
+```
+# view and select your subscription account
+
+az account list -o table
+SUBSCRIPTION=<id>
+az account set --subscription $SUBSCRIPTION
+```
+
+## Updating your source IP:
+
+Execute `./updateIP.py` prior running `terrafrom plan/apply`

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/alb.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/alb.tf
@@ -8,6 +8,7 @@ resource "azurerm_public_ip" "alb_pip" {
   sku                 = "Standard"
   allocation_method   = "Static"
   ip_version          = "IPv4"
+  tags                = local.tags
 }
 
 # Create ALB
@@ -22,6 +23,7 @@ resource "azurerm_lb" "alb" {
     public_ip_address_id = azurerm_public_ip.alb_pip.id
   }
   depends_on = [ azurerm_resource_group.rg ]
+  tags                = local.tags
 }
 
 # Create backend pool
@@ -34,7 +36,6 @@ resource "azurerm_lb_backend_address_pool" "bigip_backend_pool" {
 # Create probe
 resource "azurerm_lb_probe" "alb_probe_http" {
   name                = "http-probe"
-  resource_group_name = azurerm_resource_group.rg.name
   loadbalancer_id     = azurerm_lb.alb.id
   protocol            = "Tcp"
   port                = 80
@@ -42,7 +43,6 @@ resource "azurerm_lb_probe" "alb_probe_http" {
 
 resource "azurerm_lb_probe" "alb_probe_https" {
   name                = "https-probe"
-  resource_group_name = azurerm_resource_group.rg.name
   loadbalancer_id     = azurerm_lb.alb.id
   protocol            = "Tcp"
   port                = 443
@@ -50,7 +50,6 @@ resource "azurerm_lb_probe" "alb_probe_https" {
 
 # Create ALB rules
 resource "azurerm_lb_rule" "alb_rule_http" {
-  resource_group_name            = azurerm_resource_group.rg.name
   loadbalancer_id                = azurerm_lb.alb.id
   name                           = "alb-rule-http"
   protocol                       = "Tcp"
@@ -62,7 +61,6 @@ resource "azurerm_lb_rule" "alb_rule_http" {
 }
 
 resource "azurerm_lb_rule" "alb_rule_https" {
-  resource_group_name            = azurerm_resource_group.rg.name
   loadbalancer_id                = azurerm_lb.alb.id
   name                           = "alb-rule-https"
   protocol                       = "Tcp"

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/application.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/application.tf
@@ -72,4 +72,6 @@ resource "azurerm_virtual_machine_scale_set" "appvmss" {
       subnet_id = azurerm_subnet.internal.id
     }
   }
+
+  tags          = local.tags
 }

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/main.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/main.tf
@@ -1,26 +1,32 @@
 terraform {
-  required_version = "~> 1.1.4"
+  required_version = "~>1.3.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.94.0"
+      version = "~>3.41.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.1.0"
+      version = "~>3.4.0"
     }
     template = {
       source  = "hashicorp/template"
-      version = ">2.1.2"
+      version = "~>2.2.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">2.1.2"
+      version = "~>3.2.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.1.0"
+      version = "~>2.3.0"
     }
+  }
+}
+
+locals {
+  tags = {
+    "Owner" = var.owner
   }
 }
 
@@ -42,6 +48,7 @@ resource "random_id" "id" {
 resource "azurerm_resource_group" "rg" {
   name     = var.prefix
   location = var.location
+  tags     = local.tags
 }
 
 resource "azurerm_ssh_public_key" "f5_key" {
@@ -49,12 +56,14 @@ resource "azurerm_ssh_public_key" "f5_key" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   public_key          = file("~/.ssh/id_rsa.pub")
+  tags                = local.tags
 }
 #Create Azure Managed User Identity and Role Definition
 resource "azurerm_user_assigned_identity" "bigip_user_identity" {
   name                = "${var.prefix}-ident"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
+  tags                = local.tags
 }
 
 resource "azurerm_role_assignment" "rg_contributor" {

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/network.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/network.tf
@@ -4,6 +4,7 @@ resource "azurerm_virtual_network" "vnet" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   address_space       = [var.cidr]
+  tags                = local.tags
 }
 
 #Create the Subnets

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/security.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/security.tf
@@ -15,7 +15,7 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -28,14 +28,15 @@ resource "azurerm_network_security_group" "mgmtnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
-  tags = {
+  tags = merge({
     name        = "${var.prefix}-mgmtnsg"
     environment = var.environment
-  }
+  },
+  local.tags)
 }
 
 resource "azurerm_network_security_group" "extnsg" {
@@ -52,7 +53,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -65,7 +66,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "443"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -78,7 +79,7 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "8443"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
@@ -91,14 +92,15 @@ resource "azurerm_network_security_group" "extnsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "80"
-    source_address_prefix      = "*"
+    source_address_prefix      = var.trusted_IP
     destination_address_prefix = "*"
   }
 
-  tags = {
+  tags = merge({
     name        = "${var.prefix}-extnsg"
     environment = var.environment
-  }
+  },
+  local.tags)
 }
 
 resource "azurerm_network_security_group" "intnsg" {
@@ -119,8 +121,9 @@ resource "azurerm_network_security_group" "intnsg" {
     destination_address_prefix = "*"
   }
 
-  tags = {
+  tags = merge({
     name        = "${var.prefix}-intnsg"
     environment = var.environment
-  }
+  },
+  local.tags)
 }

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/telemetry.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/telemetry.tf
@@ -8,6 +8,7 @@ resource "azurerm_log_analytics_workspace" "law" {
   sku                 = "PerGB2018"
   retention_in_days   = 90
   depends_on = [ azurerm_resource_group.rg ]
+  tags                = local.tags
 }
 
 #Create Azure Log Analytics Workbook
@@ -32,4 +33,5 @@ resource "azurerm_application_insights" "web" {
   location            = azurerm_resource_group.rg.location
   workspace_id        = azurerm_log_analytics_workspace.law.id
   application_type    = "other"
+  tags                = local.tags
 }

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/updateIP.py
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/updateIP.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import requests
+import os
+import re
+import fileinput
+
+url = 'http://ifconfig.me/ip'
+
+response = requests.get(url)
+
+# print (response.content)
+
+with fileinput.input(files="terraform.tfvars",inplace=True) as input:
+    for line in input:
+        input_line = ''
+        search_string = re.findall(r'trusted_IP',line.strip())
+        if len(search_string) >0 :
+            input_line = "trusted_IP       = \"" + str(response.text)+"/32\""
+            print(input_line)
+        else:
+            print(line.strip())
+
+# os.system("terraform apply -target module.remote_access.module.external-network-security-group-public.aws_security_group_rule.ingress_rules[0] -auto-approve")
+# for x in range (1,4):
+#    os_command="terraform apply -target module.remote_access.module.mgmt-network-security-group.aws_security_group_rule.ingress_with_cidr_blocks["+str(x)+"] -auto-approve"
+#    os.system(os_command)

--- a/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/variables.tf
+++ b/azure-quickstarts/failover-via-lb/payg/3nic-bigip-via-lb/variables.tf
@@ -13,6 +13,16 @@ variable "prefix" {}
 variable "unique_string" {}
 variable "location" {}
 
+variable "owner" {
+  type                  = string
+  description           = "Employee e-mail address"
+}
+
+variable "trusted_IP" {
+  type    = string 
+}
+
+
 # BIGIP Instances
 variable "default_instance_count" { default = 2 }
 variable "zones" {


### PR DESCRIPTION
Hi,

I've added Source IP to the security groups, and marked all the resources with "Owner" tag.
So far I did it for azure-quickstarts/failover-via-api/payg/3nic-bigip-via-api.
Please consider creating a separate branch for F5 cloud regulation code.